### PR TITLE
fix emoji replacing error

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -161,6 +161,6 @@ export const merge = Object.assign || function (to) {
 export function emojify (text) {
   return text
     .replace(/<(pre|template)[^>]*?>([\s\S]+)<\/(pre|template)>/g, match => match.replace(/:/g, '__colon__'))
-    .replace(/:(\w*?):/ig, '<img class="emoji" src="https://assets-cdn.github.com/images/icons/emoji/$1.png" alt="$1" />')
+    .replace(/:(\w+?):/ig, '<img class="emoji" src="https://assets-cdn.github.com/images/icons/emoji/$1.png" alt="$1" />')
     .replace(/__colon__/g, ':')
 }


### PR DESCRIPTION
在做emoji替换的时候，会把`::`替换成`<img class="emoji" src="https://assets-cdn.github.com/images/icons/emoji/.png" alt="" />`，导致图片显示问题。