### PR TITLE
Correctly link Get Started

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -10,4 +10,4 @@
 
 
 [GitHub](https://github.com/QingWei-Li/docsify/)
-[Get Started](#quick-start)
+[Get Started](#docsify)


### PR DESCRIPTION
As `## docsify` is the new title of the `README.md`, *Get Started* should link to that.