### PR TITLE
fixed look of links in blockquote

### DIFF
--- a/src/themes/basic/_coverpage.css
+++ b/src/themes/basic/_coverpage.css
@@ -70,7 +70,7 @@ section.cover {
     line-height: 1.8;
   }
 
-  .cover-main p:last-child a {
+  .cover-main > p:last-child a {
     border-radius: 2em;
     border-width: 1px;
     border-style: solid;
@@ -98,6 +98,15 @@ section.cover {
 
     &:hover {
       color: inherit;
+    }
+  }
+
+  blockquote > p > a {
+    border-bottom: 2px solid var(--theme-color, $color-primary);
+    transition: color .3s;
+
+    &:hover {
+      color: var(--theme-color, $color-primary);
     }
   }
 }


### PR DESCRIPTION
This changes the look of links in the blockquote of the coverpage (as referenced in #82). It now looks like this:
![2017-02-19-144705_2560x1440_scrot](https://cloud.githubusercontent.com/assets/5368029/23102943/88078dd8-f6b2-11e6-9c06-fb1e3dea2935.png)
