### PR TITLE
Fix nav showing while loading

### DIFF
--- a/src/themes/basic/_layout.css
+++ b/src/themes/basic/_layout.css
@@ -10,7 +10,7 @@
 body:not(.ready) {
   overflow: hidden;
 
-  [data-cloak] {
+  [data-cloak], nav {
     display: none;
   }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/10095631/23514517/8982ed4e-ffa2-11e6-8898-da7541402927.png)

Currently when you open a docsify page, the top nav immediately comes up while the page is still loading. Clearly this is not desired, and this PR fixes it.