### PR TITLE
GA: Send hash instead of complete href

### DIFF
--- a/lib/plugins/ga.js
+++ b/lib/plugins/ga.js
@@ -23,7 +23,7 @@ function init (id) {
 
 function collect () {
   init(window.$docsify.ga);
-  window.ga('set', 'page', location.href);
+  window.ga('set', 'page', location.hash);
   window.ga('send', 'pageview');
 }
 


### PR DESCRIPTION
On https://docsify.js.org/#/quickstart

send "#/quickstart" instead of "https://docsify.js.org/#/quickstart"
