### PR TITLE
Fix/script in theme

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -35,7 +35,7 @@
     plugins: [
       function(hook) {
         hook.beforeEach(function (html) {
-          return html += '> Last modified {docsify-updated}'
+          return html += '\n> Last modified {docsify-updated}'
         })
       }
     ]

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
     plugins: [
       function(hook) {
         hook.beforeEach(function (html) {
-          return html += '> Last modified {docsify-updated}'
+          return html += '\n> Last modified {docsify-updated}'
         })
       }
     ]


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside lib directory.

## What?

From version 3.7.0, the "click to preview" links in [this page](https://docsify.js.org/#/themes) are broken. This patch gives a fix (workaround) to the problem.

## Why?

The appended content in index.html will be added just after the end line of theme.md. It caused markdown render to consider that script block to be embeded in a <p> tag, which in turn makes `executeScript` in index.js fail to find the script tag in that page.

## A real "fix"?

Maybe it's better to check whether a script block is valid when modifying original content by hook. Or it would be no harm to always append a new line to original markdown file end (in my mind) to avoid this.