### PR TITLE
ensure document ready before init Docsify

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pub": "sh build/release.sh"
   },
   "dependencies": {
+    "document-ready": "^2.0.1",
     "marked": "^0.3.6",
     "prismjs": "^1.6.0",
     "tinydate": "^1.0.0",

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,3 +1,4 @@
+import ready from 'document-ready'
 import { initMixin } from './init'
 import { routerMixin } from './router'
 import { renderMixin } from './render'
@@ -30,4 +31,4 @@ Docsify.version = '__VERSION__'
 /**
  * Run Docsify
  */
-setTimeout(_ => new Docsify(), 0)
+ready(_ => new Docsify())


### PR DESCRIPTION
如果在 document ready 前初始化 Docsify，后续引入的插件里 hook 不会被触发（如 afterEach）。