### PR TITLE
fix yarn add command

### DIFF
--- a/packages/docsify-server-renderer/README.md
+++ b/packages/docsify-server-renderer/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-yarn add docsify-server-render
+yarn add docsify-server-renderer
 ```
 
 ## Usage


### PR DESCRIPTION
The docsify server renderer package is published at `docsify-server-renderer` but README.md refers to `docsify-server-render`

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR. 
* [x] DO NOT include files inside lib directory.
