### PR TITLE
fix scroll issue in IE

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>docsify</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="/themes/vue.css" title="vue">
   <link rel="stylesheet" href="/themes/dark.css" title="dark" disabled>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>docsify</title>
   <link rel="icon" href="_media/favicon.ico">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="keywords" content="doc,docs,documentation,gitbook,creator,generator,github,jekyll,github-pages">
   <meta name="description" content="A magical documentation generator.">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">

--- a/src/core/event/scroll.js
+++ b/src/core/event/scroll.js
@@ -12,8 +12,8 @@ function scrollTo (el) {
   if (scroller) scroller.stop()
   enableScrollEvent = false
   scroller = new Tweezer({
-    start: window.scrollY,
-    end: el.getBoundingClientRect().top + window.scrollY,
+    start: window.pageYOffset,
+    end: el.getBoundingClientRect().top + window.pageYOffset,
     duration: 500
   })
     .on('tick', v => window.scrollTo(0, v))


### PR DESCRIPTION
Docify is not able to scroll to anchor in IE. This issue can be reproduced by using IE (for example IE 11) to visit docsify website and clicking link on sidebar.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY), property `scrollY` is not available in IE. Meanwhile, `pageYOffset` property is an alias for the `scrollY` property and is available in IE 9+ and all other browsers (details [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset)).

The other commit will add extra meta tag in html files, to force IE browsers to render page using latest version of IE available. Otherwise, it might use IE 7 to render, which will cause issues. 

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside lib directory.
