### PR TITLE
Feature propose: Make whole search result area clickable

### DIFF
--- a/src/plugins/search/component.js
+++ b/src/plugins/search/component.js
@@ -94,8 +94,10 @@ function doSearch (value) {
   let html = ''
   matchs.forEach(post => {
     html += `<div class="matching-post">
-<h2><a href="${post.url}">${post.title}</a></h2>
+<a href="${post.url}">    
+<h2>${post.title}</h2>
 <p>${post.content}</p>
+</a>
 </div>`
   })
 

--- a/src/themes/basic/_layout.css
+++ b/src/themes/basic/_layout.css
@@ -52,6 +52,7 @@ div#app {
 .search .search-keyword {
   color: var(--theme-color, $color-primary);
   font-style: normal;
+  font-weight: bold;
 }
 
 html,


### PR DESCRIPTION
Hi, I would like to propose a change to search plugin. Currently, only the title of search result is clickable. It might sound a bit weird for users as the search content is plain text and cannot redirect them.

This PR will make the complete area clickable by wrapping the whole area with a tag.

One thing to notice is that the search keyword will be rendered using theme color, the same color when mouse hovered. To distinguish them, I made the keyword also bold.

How it looks when displaying search result:

![image](https://user-images.githubusercontent.com/1191606/31643772-1594eec8-b325-11e7-985c-4587c4cbb340.png)

How it looks when mouse hovered:

![image](https://user-images.githubusercontent.com/1191606/31643801-376de482-b325-11e7-81e3-9718f5fb595e.png)

Should work fine with all default themes. But perhaps not a very well-designed. Let me know if you have any feedback.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside lib directory.
