### PR TITLE
fix issue disqus plugin issue

### DIFF
--- a/src/plugins/disqus.js
+++ b/src/plugins/disqus.js
@@ -1,4 +1,7 @@
-location.href = location.href.replace('/-/', '/#/')
+const fixedPath = location.href.replace('/-/', '/#/')
+if (fixedPath != location.href) {
+  location.href = location.href.replace('/-/', '/#/')
+}
 
 function install (hook, vm) {
   const dom = Docsify.dom

--- a/src/plugins/disqus.js
+++ b/src/plugins/disqus.js
@@ -1,6 +1,6 @@
 const fixedPath = location.href.replace('/-/', '/#/')
 if (fixedPath != location.href) {
-  location.href = location.href.replace('/-/', '/#/')
+  location.href = fixedPath
 }
 
 function install (hook, vm) {


### PR DESCRIPTION
fix #317, disqus plugin make page refresh continuously.

```
location.href = location.href.replace('/-/', '/#/')
```

如果打开的是根目录，就会出现`/` 会被route改成`/#/`，然后这句话由把href改回`/`无限循环了。
我简单做了个保护。。。单由于不太理解这句话的含义，所以也不知道这样改有没有副作用。我在我的环境里没测试出问题。