### PR TITLE
updated deps to fix security (marked upgraded)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4229,9 +4229,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pub": "sh build/release.sh"
   },
   "dependencies": {
-    "marked": "^0.3.6",
+    "marked": "^0.3.9",
     "medium-zoom": "^0.2.0",
     "prismjs": "^1.6.0",
     "tinydate": "^1.0.0",


### PR DESCRIPTION
Upgrade `marked` for security reasons:
https://nvd.nist.gov/vuln/detail/CVE-2017-17461
https://nvd.nist.gov/vuln/detail/CVE-2017-1000427