### PR TITLE
Fixing default option for externalLinkTarget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -343,7 +343,7 @@ window.$docsify = {
 ## external-link-target
 
 - type: `String`
-- default: `_self`
+- default: `_blank`
 
 Target to open external links. Default `'_blank'` (new window/tab)
 


### PR DESCRIPTION
Based on my interactions with Docsify and the context to that line, it seems as though that may have been a quick typo! I'm just fixing it, as it said the default is `_self` not `_blank` :)

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside lib directory.
