### PR TITLE
feat(fetch): Add fallback languages configuration.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -413,3 +413,25 @@ window.$docsify = {
   ext: '.md'
 };
 ```
+
+## fallbackLanguages
+
+* type: `Array<string>`
+
+List of languages that will fallback to the default language when a page is request and didn't exists for the given local.
+
+Example: 
+ 
+ - try to fetch the page of `/de/overview`. If this page exists, it'll be displayed
+ - then try to fetch the default page `/overview` (depending on the default language). If this page exists, it'll be displayed
+ - then display 404 page.
+
+
+```js
+window.$docsify = {
+  fallbackLanguages: [
+    "fr",
+    "de"
+  ]
+};
+```


### PR DESCRIPTION
fallbackLanguages give the possibility to configure a list of languages which must used the default language when a page is missing in the requested language.

## Example
## fallbackLanguages

* type: `Array<string>`

List of languages that will fallback to the default language when a page is request and didn't exists for the given local.

Example: 
 
 - try to fetch the page of `/de/overview`. If this page exists, it'll be displayed
 - then try to fetch the default page `/overview` (depending on the default language). If this page exists, it'll be displayed
 - then display 404 page.


```js
window.$docsify = {
  fallbackLanguages: [
    "fr",
    "de"
  ]
};
```
***
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
