### PR TITLE
fix(render): Disable markdown parsing when the file is an HTML

### DIFF
--- a/src/core/fetch/index.js
+++ b/src/core/fetch/index.js
@@ -27,10 +27,12 @@ export function fetchMixin (proto) {
     // Abort last request
     last && last.abort && last.abort()
 
-    last = get(this.router.getFile(path) + qs, true, requestHeaders)
+    const file = this.router.getFile(path)
+
+    last = get(file + qs, true, requestHeaders)
 
     // Current page is html
-    this.isHTML = /\.html$/g.test(path)
+    this.isHTML = /\.html$/g.test(file)
 
     const loadSideAndNav = () => {
       if (!loadSidebar) return cb()

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -135,7 +135,7 @@ export function renderMixin (proto) {
         callHook(this, 'afterEach', html, text => renderMain.call(this, text))
       }
       if (this.isHTML) {
-        html = this.result
+        html = this.result = text
         callback()
         next()
       } else {


### PR DESCRIPTION
When a file is a HTML, the markdown parse the file. This behavior isn't not expected. This PR fix that.