### PR TITLE
fix(navbar): Now Navbar isn't append to DOM when loadNavbar is falsy

### DIFF
--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -6,7 +6,10 @@ import { scrollIntoView } from './scroll'
 export function eventMixin (proto) {
   proto.$resetEvents = function () {
     scrollIntoView(this.route.path, this.route.query.id)
-    sidebar.getAndActive(this.router, 'nav')
+
+    if (this.config.loadNavbar) {
+      sidebar.getAndActive(this.router, 'nav')
+    }
   }
 }
 

--- a/src/core/render/index.js
+++ b/src/core/render/index.js
@@ -117,7 +117,9 @@ export function renderMixin (proto) {
 
   proto._renderNav = function (text) {
     text && this._renderTo('nav', this.compiler.compile(text))
-    getAndActive(this.router, 'nav')
+    if (this.config.loadNavbar) {
+      getAndActive(this.router, 'nav')
+    }
   }
 
   proto._renderMain = function (text, opt = {}, next) {
@@ -238,7 +240,9 @@ export function initRender (vm) {
   }
 
   // Add nav
-  dom.before(navAppendToTarget, navEl)
+  if (config.loadNavbar) {
+    dom.before(navAppendToTarget, navEl)
+  }
 
   if (config.themeColor) {
     dom.$.head.appendChild(


### PR DESCRIPTION
Navbar is added to the DOM. It's not necessary when loadNavbar is falsy :)