### PR TITLE
update: docsify-copy-code static path use 1.0.0.

### DIFF
--- a/docs/zh-cn/plugins.md
+++ b/docs/zh-cn/plugins.md
@@ -119,8 +119,8 @@ Medium's 风格的图片缩放插件. 基于 [medium-zoom](https://github.com/fr
 Add a simple `Click to copy` button to all preformatted code blocks to effortlessly allow users to copy example code from your docs. Provided by [@jperasmus](https://github.com/jperasmus)
 
 ```html
-<link rel="stylesheet" href="//unpkg.com/docsify-copy-code/styles.css">
-<script src="//unpkg.com/docsify-copy-code/index.js"></script>
+<link rel="stylesheet" href="//unpkg.com/docsify-copy-code@1.0.0/styles.css">
+<script src="//unpkg.com/docsify-copy-code@1.0.0/index.js"></script>
 ```
 
 ```javascript


### PR DESCRIPTION
docsify-copy-code has release `2.0.0`，static path default point `2.0.0`，but the structure of the project has changed，All of the 1.0.0 versions will be wrong.
