### PR TITLE
docs: Update installation instructions for v2 of `docsify-copy-code` …

### DIFF
--- a/docs/de-de/plugins.md
+++ b/docs/de-de/plugins.md
@@ -4,7 +4,6 @@
 
 Als Standardeinstellung werden Hyperlinks auf der aktuellen Seite erkannt und der Inhalt in `localStorage` gespeichert. Du kannst den Pfad zu den Dateien auch anpassen:
 
-
 ```html
 <script>
   window.$docsify = {
@@ -67,7 +66,6 @@ Konfiguration über `data-ga`:
 <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
 ```
 
-
 ## emoji
 
 Als Standardeinstellung werden emojis umgewandelt. Als Beispiel wird `:100:` umgewandelt in :100:. Aber das ist nicht genau, das es keine passende Nicht-emoji Zeichenfolge gibt. Solltest du emojis richtig umwandeln wollen, musst du diese Erweiterung verwenden.
@@ -106,7 +104,6 @@ When readers expand the demo box, the source code and description are shown ther
 
 [Vue](https://njleonzhang.github.io/docsify-demo-box-vue/) and [React](https://njleonzhang.github.io/docsify-demo-box-react/) are both supported.
 
-
 ## Edit on github
 
 Add `Edit on github` button on every pages. Provided by [@njleonzhang](https://github.com/njleonzhang), check [document](https://github.com/njleonzhang/docsify-edit-on-github)
@@ -116,21 +113,10 @@ Add `Edit on github` button on every pages. Provided by [@njleonzhang](https://g
 Add a simple `Click to copy` button to all preformatted code blocks to effortlessly allow users to copy example code from your docs. Provided by [@jperasmus](https://github.com/jperasmus)
 
 ```html
-<link rel="stylesheet" href="//unpkg.com/docsify-copy-code/styles.css">
-<script src="//unpkg.com/docsify-copy-code/index.js"></script>
-```
-
-```javascript
-window.$docsify = {
-  plugins: [
-    window.DocsifyCopyCodePlugin.init()
-  ]
-}
+<script src="//unpkg.com/docsify-copy-code"></script>
 ```
 
 See [here](https://github.com/jperasmus/docsify-copy-code/blob/master/README.md) for more details.
-
-
 
 ## Disqus
 
@@ -145,10 +131,9 @@ Disqus comments. https://disqus.com/
 <script src="//unpkg.com/docsify/lib/plugins/disqus.min.js"></script>
 ```
 
-
 ## Gitalk
 
-[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact. 
+[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact.
 
 ```html
 <link rel="stylesheet" href="//unpkg.com/gitalk/dist/gitalk.css">

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,7 +4,6 @@
 
 By default, the hyperlink on the current page is recognized and the content is saved in `localStorage`. You can also specify the path to the files.
 
-
 ```html
 <script>
   window.$docsify = {
@@ -67,7 +66,6 @@ Configure by `data-ga`.
 <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
 ```
 
-
 ## emoji
 
 The default is to support parsing emoji. For example `:100:` will be parsed to :100:. But it is not precise because there is no matching non-emoji string. If you need to correctly parse the emoji string, you need install this plugin.
@@ -98,7 +96,6 @@ Exclude the special image
 ![](image.png ':no-zoom')
 ```
 
-
 ## Edit on github
 
 Add `Edit on github` button on every pages. Provided by [@njleonzhang](https://github.com/njleonzhang), check [document](https://github.com/njleonzhang/docsify-edit-on-github)
@@ -111,26 +108,15 @@ When readers expand the demo box, the source code and description are shown ther
 
 [Vue](https://njleonzhang.github.io/docsify-demo-box-vue/) and [React](https://njleonzhang.github.io/docsify-demo-box-react/) are both supported.
 
-
 ## Copy to Clipboard
 
 Add a simple `Click to copy` button to all preformatted code blocks to effortlessly allow users to copy example code from your docs. Provided by [@jperasmus](https://github.com/jperasmus)
 
 ```html
-<link rel="stylesheet" href="//unpkg.com/docsify-copy-code/styles.css">
-<script src="//unpkg.com/docsify-copy-code/index.js"></script>
-```
-
-```javascript
-window.$docsify = {
-  plugins: [
-    window.DocsifyCopyCodePlugin.init()
-  ]
-}
+<script src="//unpkg.com/docsify-copy-code"></script>
 ```
 
 See [here](https://github.com/jperasmus/docsify-copy-code/blob/master/README.md) for more details.
-
 
 ## Disqus
 
@@ -147,7 +133,7 @@ Disqus comments. https://disqus.com/
 
 ## Gitalk
 
-[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact. 
+[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact.
 
 ```html
 <link rel="stylesheet" href="//unpkg.com/gitalk/dist/gitalk.css">
@@ -175,4 +161,3 @@ Pagination for docsify. By [@imyelo](https://github.com/imyelo)
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
 ```
-

--- a/docs/zh-cn/plugins.md
+++ b/docs/zh-cn/plugins.md
@@ -4,7 +4,6 @@
 
 全文搜索插件会根据当前页面上的超链接获取文档内容，在 `localStorage` 内建立文档索引。默认过期时间为一天，当然我们可以自己指定需要缓存的文件列表或者配置过期时间。
 
-
 ```html
 <script>
   window.$docsify = {
@@ -91,7 +90,6 @@ When readers expand the demo box, the source code and description are shown ther
 
 [Vue](https://njleonzhang.github.io/docsify-demo-box-vue/) and [React](https://njleonzhang.github.io/docsify-demo-box-react/) are both supported.
 
-
 ## 图片缩放 - Zoom image
 
 Medium's 风格的图片缩放插件. 基于 [medium-zoom](https://github.com/francoischalifour/medium-zoom)。
@@ -100,40 +98,25 @@ Medium's 风格的图片缩放插件. 基于 [medium-zoom](https://github.com/fr
 <script src="//unpkg.com/docsify/lib/plugins/zoom-image.js"></script>
 ```
 
-
 忽略某张图片
 
 ```markdown
 ![](image.png ':no-zoom')
 ```
 
-
-
 ## 在 Github 上编辑
 
 在每一页上添加 `Edit on github` 按钮. 由第三方库提供, 查看 [document](https://github.com/njleonzhang/docsify-edit-on-github)
-
 
 ## Copy to Clipboard
 
 Add a simple `Click to copy` button to all preformatted code blocks to effortlessly allow users to copy example code from your docs. Provided by [@jperasmus](https://github.com/jperasmus)
 
 ```html
-<link rel="stylesheet" href="//unpkg.com/docsify-copy-code/styles.css">
-<script src="//unpkg.com/docsify-copy-code/index.js"></script>
-```
-
-```javascript
-window.$docsify = {
-  plugins: [
-    window.DocsifyCopyCodePlugin.init()
-  ]
-}
+<script src="//unpkg.com/docsify-copy-code"></script>
 ```
 
 See [here](https://github.com/jperasmus/docsify-copy-code/blob/master/README.md) for more details.
-
-
 
 ## Disqus
 
@@ -148,10 +131,9 @@ Disqus comments. https://disqus.com/
 <script src="//unpkg.com/docsify/lib/plugins/disqus.min.js"></script>
 ```
 
-
 ## Gitalk
 
-[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact. 
+[Gitalk](https://github.com/gitalk/gitalk) is a modern comment component based on Github Issue and Preact.
 
 ```html
 <link rel="stylesheet" href="//unpkg.com/gitalk/dist/gitalk.css">


### PR DESCRIPTION
The `docsify-copy-code` plugin has recently been updated to v2 introducing some breaking changes to the installation/setup process. This PR updates the docs to show the new simplified setup requirements.

It addresses: https://github.com/QingWei-Li/docsify/issues/462

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] DO NOT include files inside `lib` directory.
